### PR TITLE
Mapping execute on different in out models

### DIFF
--- a/src/DateUtils.ts
+++ b/src/DateUtils.ts
@@ -31,23 +31,23 @@ export function newUTCDate(
 
 export function formatYYYYMMdd(date: Date): string {
   const utcDate = clone(date);
-  return utcDate.getFullYear().toString() + pad(utcDate.getMonth() + 1, 2) + pad(utcDate.getDate(), 2);
+  return utcDate.getUTCFullYear().toString() + pad(utcDate.getUTCMonth() + 1, 2) + pad(utcDate.getUTCDate(), 2);
 }
 
 export function formatddMMYYYY(date: Date): string {
   const utcDate = clone(date);
-  return pad(utcDate.getDate(), 2) + pad(utcDate.getMonth() + 1, 2) + utcDate.getFullYear();
+  return pad(utcDate.getUTCDate(), 2) + pad(utcDate.getUTCMonth() + 1, 2) + utcDate.getUTCFullYear();
 }
 
 export function formatReadable(date: Date): string {
   const utcDate = clone(date);
-  return pad(utcDate.getDate(), 2) + '/' + pad(utcDate.getMonth() + 1, 2) + '/' + utcDate.getFullYear();
+  return pad(utcDate.getUTCDate(), 2) + '/' + pad(utcDate.getUTCMonth() + 1, 2) + '/' + utcDate.getUTCFullYear();
 }
 
 export function formatMMMMYYYY(date: Date, locale?: string): string {
   const utcDate = clone(date);
   const monthFormat = new Intl.DateTimeFormat(locale, { month: 'long' });
-  return monthFormat.format(date) + ' ' + utcDate.getFullYear();
+  return monthFormat.format(date) + ' ' + utcDate.getUTCFullYear();
 }
 
 export function formatEEEEddMMMM(date: Date, locale?: string): string {
@@ -56,7 +56,7 @@ export function formatEEEEddMMMM(date: Date, locale?: string): string {
   const weekday = weekdayFormat.format(utcDate);
   const monthFormat = new Intl.DateTimeFormat(locale, { month: 'long' });
   const month = monthFormat.format(utcDate);
-  return weekday + ' ' + pad(utcDate.getDate(), 2) + ' ' + month;
+  return weekday + ' ' + pad(utcDate.getUTCDate(), 2) + ' ' + month;
 }
 
 export function formatTime(date: Date): string {
@@ -73,9 +73,9 @@ export function parse(yyyyMMdd: string): Date {
 
 export function numberOfFullMonthsBetween(left: Date, right?: Date): number {
   const today = right ? right : now();
-  const y = today.getFullYear() - left.getFullYear();
-  const m = today.getMonth() - left.getMonth();
-  const d = today.getDay() - left.getDate();
+  const y = today.getUTCFullYear() - left.getUTCFullYear();
+  const m = today.getUTCMonth() - left.getUTCMonth();
+  const d = today.getUTCDay() - left.getUTCDate();
   const res = y * 12 + m;
   if (d >= 0) {
     return res;

--- a/src/doov.ts
+++ b/src/doov.ts
@@ -25,7 +25,7 @@ export function f<T>(accessor: ContextAccessor<object, Context, T>): Function<T>
   return Function.function(accessor);
 }
 
-export function field<T extends object, V>(...path: (string | number)[]): Field<T, Context, V> {
+export function field<V, T extends object = object>(...path: (string | number)[]): Field<T, Context, V> {
   return Field.field(...path);
 }
 

--- a/src/dsl/Field.ts
+++ b/src/dsl/Field.ts
@@ -20,7 +20,7 @@ export class Field<T extends object = object, C extends Context = Context, V = {
     this.metadata = metadata;
   }
 
-  public static field<T extends object, V>(...path: (string | number)[]): Field<T, Context, V> {
+  public static field<V, T extends object = object>(...path: (string | number)[]): Field<T, Context, V> {
     return new Field(new FieldMetadata(path));
   }
 

--- a/src/dsl/lang/ConditionalMapping.ts
+++ b/src/dsl/lang/ConditionalMapping.ts
@@ -39,12 +39,12 @@ export class ConditionalMapping implements MappingRule {
     const context = ctx ? ctx : new DefaultContext();
     if (this.condition.get(input, ctx)) {
       this.mappings.forEach(m => {
-        m.executeOn(input, output, context);
+        output = m.executeOn(input, output, context);
       });
       return output;
     } else if (this.elseMappings) {
       this.elseMappings.forEach(m => {
-        m.executeOn(input, output, context);
+        output = m.executeOn(input, output, context);
       });
       return output;
     } else {

--- a/src/dsl/lang/IterableFunction.ts
+++ b/src/dsl/lang/IterableFunction.ts
@@ -4,9 +4,10 @@ import { Context } from '../Context';
 import { BooleanFunction } from './BooleanFunction';
 import { BinaryMetadata } from '../meta/BinaryMetadata';
 import { ValueMetadata } from '../meta/ValueMetadata';
-import { CONTAINS, CONTAINS_ALL, HAS_NOT_SIZE, HAS_SIZE, IS_EMPTY, IS_NOT_EMPTY } from './DefaultOperators';
+import { CONTAINS, CONTAINS_ALL, HAS_NOT_SIZE, HAS_SIZE, IS_EMPTY, IS_NOT_EMPTY, LENGTH } from './DefaultOperators';
 import { IterableMetadata } from '../meta/IterableMetadata';
 import { UnaryMetadata } from '../meta/UnaryMetadata';
+import { NumberFunction } from './NumberFunction';
 export class IterableFunction<T> extends Function<T[]> {
   public static iterable<T>(accessor: ContextAccessor<object, Context, T[]>): IterableFunction<T> {
     return new IterableFunction(accessor.metadata, accessor.get, accessor.set);
@@ -78,5 +79,19 @@ export class IterableFunction<T> extends Function<T[]> {
         condition(this, value, predicate, null)
       );
     }
+  }
+
+  public length(): NumberFunction {
+    return new NumberFunction(
+      new UnaryMetadata(this.metadata, LENGTH),
+      condition(
+        this,
+        undefined,
+        (left: T[]) => {
+          return left.length;
+        },
+        null
+      )
+    );
   }
 }

--- a/src/dsl/lang/MappingRule.ts
+++ b/src/dsl/lang/MappingRule.ts
@@ -2,5 +2,6 @@ import { DslBuilder } from '../DslBuilder';
 import { Context } from '../Context';
 
 export interface MappingRule extends DslBuilder {
-  execute<M extends object>(model: M, ctx?: Context): M;
+  execute<M extends object>(input: M, ctx?: Context): M;
+  executeOn<M extends object, O extends object>(input: M, output: O, ctx?: Context): O;
 }

--- a/src/dsl/lang/Mappings.ts
+++ b/src/dsl/lang/Mappings.ts
@@ -1,6 +1,7 @@
 import { MappingRule } from './MappingRule';
 import { Context } from '../Context';
 import { MultipleMappingsMetadata } from '../meta/MultipleMappingsMetadata';
+import { DefaultContext } from '../DefaultContext';
 
 export class Mappings implements MappingRule {
   readonly metadata: MultipleMappingsMetadata;
@@ -11,7 +12,16 @@ export class Mappings implements MappingRule {
     this.metadata = new MultipleMappingsMetadata(this.mappings.map(value => value.metadata));
   }
 
-  execute<M extends object>(model: M, ctx?: Context): M {
-    return this.mappings.reduce((mdl, mapping) => mapping.execute(mdl, ctx), model);
+  execute<M extends object>(input: M, ctx?: Context): M {
+    const context = ctx ? ctx : new DefaultContext();
+    return this.mappings.reduce((mdl, mapping) => mapping.execute(mdl, context), input);
+  }
+
+  executeOn<M extends object, O extends object>(input: M, output: O, ctx?: Context): O {
+    const context = ctx ? ctx : new DefaultContext();
+    this.mappings.forEach(m => {
+      m.executeOn(input, output, context);
+    });
+    return output;
   }
 }

--- a/src/dsl/lang/Mappings.ts
+++ b/src/dsl/lang/Mappings.ts
@@ -20,7 +20,7 @@ export class Mappings implements MappingRule {
   executeOn<M extends object, O extends object>(input: M, output: O, ctx?: Context): O {
     const context = ctx ? ctx : new DefaultContext();
     this.mappings.forEach(m => {
-      m.executeOn(input, output, context);
+      output = m.executeOn(input, output, context);
     });
     return output;
   }

--- a/src/dsl/lang/SingleMappingRule.ts
+++ b/src/dsl/lang/SingleMappingRule.ts
@@ -15,12 +15,21 @@ export class SingleMappingRule<T> implements MappingRule {
     this.metadata = new SingleMappingMetadata(input.metadata, output.metadata);
   }
 
-  public execute<M extends object>(model: M, ctx?: Context): M {
+  public execute<M extends object>(input: M, ctx?: Context): M {
     const context = ctx ? ctx : new DefaultContext();
     if (this.output.set) {
-      return this.output.set(model, this.input.get(model, context), context) as M;
+      return this.output.set(input, this.input.get(input, context), context) as M;
     } else {
-      return model;
+      return input;
+    }
+  }
+
+  public executeOn<M extends object, O extends object>(input: M, output: O, ctx?: Context): O {
+    const context = ctx ? ctx : new DefaultContext();
+    if (this.output.set) {
+      return this.output.set(output, this.input.get(input, context), context) as O;
+    } else {
+      return output;
     }
   }
 }

--- a/src/dsl/lang/StringFunction.ts
+++ b/src/dsl/lang/StringFunction.ts
@@ -43,9 +43,8 @@ export class StringFunction extends Function<string> {
   }
 
   public matches(regex: string | StringFunction): BooleanFunction {
-    const predicate = (value: string, str: string) => {
-      const match = value.match(str);
-      return match != null && match.length >= 1;
+    const predicate = (value: string, regexp: string) => {
+      return new RegExp(regexp).test(value);
     };
     if (regex instanceof StringFunction) {
       return new BooleanFunction(

--- a/src/dsl/meta/UnaryMetadata.ts
+++ b/src/dsl/meta/UnaryMetadata.ts
@@ -1,6 +1,7 @@
 import { Metadata } from './Metadata';
 import { Operator } from '../Operator';
 import { AbstractMetadata } from './AbstractMetadata';
+import { NOT } from '../lang/DefaultOperators';
 
 export class UnaryMetadata extends AbstractMetadata {
   readonly type = 'UNARY';
@@ -14,6 +15,9 @@ export class UnaryMetadata extends AbstractMetadata {
   }
 
   get readable(): string {
+    if (this.operator === NOT) {
+      return this.operator.readable + '(' + this.metadata.readable + ')';
+    }
     return this.metadata.readable + ' ' + this.operator.readable;
   }
 

--- a/src/dsl/meta/ValueMetadata.ts
+++ b/src/dsl/meta/ValueMetadata.ts
@@ -7,7 +7,7 @@ export class ValueMetadata extends AbstractMetadata {
 
   public constructor(value: unknown | null) {
     super();
-    this.readable = String(value);
+    this.readable = JSON.stringify(value);
     this.value = value;
   }
 }

--- a/test/doov.test.ts
+++ b/test/doov.test.ts
@@ -5,11 +5,11 @@ import * as DOOV from '../src/doov';
 let model: Model;
 let user: User;
 
-const name = DOOV.string(DOOV.field<Model, string>('user', 'name'));
-const a = DOOV.boolean(DOOV.field<Model, boolean>('user', 'b'));
-const id = DOOV.number(DOOV.field<Model, number>('user', 'id'));
-const link1 = DOOV.string(DOOV.field<Model, string>('user', 'links', 0));
-const link2 = DOOV.string(DOOV.field<Model, string>('user', 'links', 1));
+const name = DOOV.string(DOOV.field<string>('user', 'name'));
+const a = DOOV.boolean(DOOV.field<boolean>('user', 'b'));
+const id = DOOV.number(DOOV.field<number>('user', 'id'));
+const link1 = DOOV.string(DOOV.field<string>('user', 'links', 0));
+const link2 = DOOV.string(DOOV.field<string>('user', 'links', 1));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/Field.test.ts
+++ b/test/dsl/Field.test.ts
@@ -8,10 +8,10 @@ import { StringFunction } from '../../src/dsl/lang/StringFunction';
 let model: Model;
 let user: User;
 
-const stringField = DOOV.field<Model, string>('user', 'name');
-const arrayField = DOOV.field<Model, string>('user', 'links', 0);
-const userIdField = DOOV.field<Model, string>('user', 'id').withTags('id');
-const birthDateField = DOOV.field<Model, Date>('user', 'birth').withPosition(1);
+const stringField = DOOV.field<string, Model>('user', 'name');
+const arrayField = DOOV.field<string, Model>('user', 'links', 0);
+const userIdField = DOOV.field<string, Model>('user', 'id').withTags('id');
+const birthDateField = DOOV.field<Date, Model>('user', 'birth').withPosition(1);
 const birthDateFunction = DOOV.date(birthDateField);
 const userIdFunction = DOOV.string(userIdField);
 const liftedDateFunction = DOOV.lift(DateFunction, new Date());

--- a/test/dsl/lang/BooleanFunction.test.ts
+++ b/test/dsl/lang/BooleanFunction.test.ts
@@ -9,8 +9,8 @@ let user: User;
 const trueFunction = DOOV.lift(BooleanFunction, true);
 const falseFunction = DOOV.lift(BooleanFunction, false);
 const nullField = DOOV.lift(BooleanFunction, null as any);
-const trueField = DOOV.boolean(DOOV.field<Model, boolean>('user', 'b'));
-const undefinedField = DOOV.boolean(DOOV.field<Model, boolean>('user', 'a'));
+const trueField = DOOV.boolean(DOOV.field<boolean, Model>('user', 'b'));
+const undefinedField = DOOV.boolean(DOOV.field<boolean, Model>('user', 'a'));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/lang/Context.test.ts
+++ b/test/dsl/lang/Context.test.ts
@@ -8,10 +8,10 @@ import { DefaultContext } from '../../../src/dsl/DefaultContext';
 let model: Model;
 let user: User;
 
-const B = DOOV.boolean(DOOV.field<Model, boolean>('user', 'b'));
-const ID = DOOV.number(DOOV.field<Model, number>('user', 'id'));
-const NAME: StringFunction = DOOV.string(Field.field<Model, string>('user', 'name'));
-const LINK1 = DOOV.string(DOOV.field<Model, string>('user', 'links', 0));
+const B = DOOV.boolean(DOOV.field<boolean, Model>('user', 'b'));
+const ID = DOOV.number(DOOV.field<number, Model>('user', 'id'));
+const NAME: StringFunction = DOOV.string(Field.field<string, Model>('user', 'name'));
+const LINK1 = DOOV.string(DOOV.field<string, Model>('user', 'links', 0));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/lang/DateFunction.test.ts
+++ b/test/dsl/lang/DateFunction.test.ts
@@ -10,8 +10,8 @@ let user: User;
 const date = new Date(2019, 8, 11);
 const birthDate = new Date(2000, 0, 2);
 const dateFunction = DOOV.lift(DateFunction, date);
-const dateField = DOOV.date(DOOV.field<object, Date>('user', 'birth'));
-const nameField = DOOV.string(DOOV.field<object, string>('user', 'name'));
+const dateField = DOOV.date(DOOV.field<Date>('user', 'birth'));
+const nameField = DOOV.string(DOOV.field<string>('user', 'name'));
 const dateNameField = DOOV.dateIso(nameField);
 
 beforeEach(() => {

--- a/test/dsl/lang/Function.test.ts
+++ b/test/dsl/lang/Function.test.ts
@@ -15,9 +15,9 @@ const someStrFunction = DOOV.lift(StringFunction, 'some');
 const nullField = DOOV.lift(StringFunction, null as any);
 const otherStrFunction = DOOV.lift(StringFunction, 'other');
 // re-wrap function, to test getter/setter interception
-const nameField = DOOV.f(DOOV.string(DOOV.field<Model, string>('user', 'name')));
-const undefinedField = DOOV.boolean(DOOV.field<Model, boolean>('user', 'a'));
-const booleanFunction = DOOV.f(DOOV.field<Model, boolean>('user', 'b'));
+const nameField = DOOV.f(DOOV.string(DOOV.field<string, Model>('user', 'name')));
+const undefinedField = DOOV.boolean(DOOV.field<boolean, Model>('user', 'a'));
+const booleanFunction = DOOV.f(DOOV.field<boolean, Model>('user', 'b'));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/lang/IterableFunction.test.ts
+++ b/test/dsl/lang/IterableFunction.test.ts
@@ -13,7 +13,7 @@ const numberFunction = DOOV.lift(NumberFunction, 2);
 const stringFunction = DOOV.lift(StringFunction, 'link1');
 const iterableFunction = DOOV.lift(IterableFunction, [true, false] as boolean[]);
 const undefinedIterable = DOOV.lift(IterableFunction, undefined);
-const linksField = DOOV.iterable(DOOV.field<Model, string[]>('user', 'links'));
+const linksField = DOOV.iterable(DOOV.field<string[], Model>('user', 'links'));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/lang/IterableFunction.test.ts
+++ b/test/dsl/lang/IterableFunction.test.ts
@@ -76,4 +76,9 @@ describe('iterable function', () => {
     expect(linksField.contains('link2').get(model)).toEqual(true);
     expect(linksField.contains(stringFunction).get(model)).toEqual(true);
   });
+  it('iterable length', () => {
+    expect(linksField.isUndefined().get(model)).toEqual(true);
+    model = linksField.set!(model, ['link1', 'link2']);
+    expect(linksField.length().get(model)).toEqual(2);
+  });
 });

--- a/test/dsl/lang/Mapping.test.ts
+++ b/test/dsl/lang/Mapping.test.ts
@@ -11,10 +11,10 @@ import { biConverter } from '../../../src/doov';
 let model: Model;
 let user: User;
 
-const id = DOOV.number(DOOV.field<Model, number>('user', 'id'));
-const name = DOOV.string(DOOV.field<Model, string>('user', 'name'));
-const link1 = DOOV.string(DOOV.field<Model, string>('user', 'links', 0));
-const link2 = DOOV.string(DOOV.field<Model, string>('user', 'links', 1));
+const id = DOOV.number(DOOV.field<number, Model>('user', 'id'));
+const name = DOOV.string(DOOV.field<string, Model>('user', 'name'));
+const link1 = DOOV.string(DOOV.field<string, Model>('user', 'links', 0));
+const link2 = DOOV.string(DOOV.field<string, Model>('user', 'links', 1));
 
 const reverse = DOOV.converter((obj, input: Function<string>) => {
   const value = input.get(obj);

--- a/test/dsl/lang/NumberFunction.test.ts
+++ b/test/dsl/lang/NumberFunction.test.ts
@@ -7,8 +7,8 @@ let model: Model;
 let user: User;
 
 const num = DOOV.lift(NumberFunction, 3);
-const id = DOOV.number(DOOV.field<Model, number>('user', 'id'));
-const nullField = DOOV.number(DOOV.field<Model, number>('user', 'a'));
+const id = DOOV.number(DOOV.field<number, Model>('user', 'id'));
+const nullField = DOOV.number(DOOV.field<number, Model>('user', 'a'));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/lang/StringFunction.test.ts
+++ b/test/dsl/lang/StringFunction.test.ts
@@ -6,8 +6,8 @@ let model: Model;
 let user: User;
 
 const num4 = DOOV.lift(StringFunction, '#4');
-const name = DOOV.string(DOOV.field<Model, string>('user', 'name'));
-const link1 = DOOV.string(DOOV.field<Model, string>('user', 'links', 0));
+const name = DOOV.string(DOOV.field<string, Model>('user', 'name'));
+const link1 = DOOV.string(DOOV.field<string, Model>('user', 'links', 0));
 
 beforeEach(() => {
   model = new Model();

--- a/test/dsl/meta/Metadata.test.ts
+++ b/test/dsl/meta/Metadata.test.ts
@@ -8,10 +8,10 @@ let model: Model;
 let user: User;
 let metadata: Metadata | undefined;
 
-const nameField = DOOV.field<Model, string>('user', 'name');
+const nameField = DOOV.field<string, Model>('user', 'name');
 let name = DOOV.string(nameField);
-let link1 = DOOV.string(DOOV.field<Model, string>('user', 'links', 0));
-let id = DOOV.number(DOOV.field<Model, number>('user', 'id'));
+let link1 = DOOV.string(DOOV.field<string, Model>('user', 'links', 0));
+let id = DOOV.number(DOOV.field<number, Model>('user', 'id'));
 
 beforeEach(() => {
   model = new Model();


### PR DESCRIPTION
- `executeOn` method for `MappingRule` to execute on an output object different than the input.
(The output object is still a copy)
- Fix StringFunction#matches issue with regexp
- Value metadata stringifies the wrapped value for readable
- Model generic type for Field is now optional and by default `object`. This means to switch the order of generic types of field type and field model.
- Unary metadata prefixes the operator `not` for readable